### PR TITLE
Fixed some dupping methods!

### DIFF
--- a/Creative(+NBT)Control/src/config.yml
+++ b/Creative(+NBT)Control/src/config.yml
@@ -108,3 +108,5 @@ ChatMessages:
     NoPermission: '&4[System] &cYou don''t have permission!'
     CmdHelp: '&4[System] &cAvailable commands:&6 /cnc reload'
     CmdReload: '&2[System] &aConfig reload complete!'
+    OpenSurvivalFrame: '&6[System] &eYou must be in survival mode to place an item in a frame!'
+    OpenSurvivalArmor: '&6[System] &eYou must be in survival mode to place items in an armor stand!'

--- a/Creative(+NBT)Control/src/net/craftersland/creativeNBT/events/CreativeEvent.java
+++ b/Creative(+NBT)Control/src/net/craftersland/creativeNBT/events/CreativeEvent.java
@@ -4,28 +4,34 @@ import net.craftersland.creativeNBT.CC;
 
 import org.bukkit.GameMode;
 import org.bukkit.Material;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCreativeEvent;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SpawnEggMeta;
 
 public class CreativeEvent implements Listener {
-	
+
 	private CC cc;
-	
+
 	public CreativeEvent(CC cc) {
 		this.cc = cc;
 	}
-	
-	@EventHandler
+
+	@EventHandler(ignoreCancelled = true)
 	public void inventoryClickEvent(final InventoryClickEvent event) {
 		//Triggers on other inventory click
-		//CC.log.warning("Debug 1 - " + event.getClick().isCreativeAction() + " - " + event.getClick().isRightClick() + " - " + event.getClick().isLeftClick() + " - " + event.getClick());
-		if (event.getClick() == ClickType.MIDDLE && event.getClick().isCreativeAction() == true) {
+		//CC.log.warning("Debug 1 - " + event.getClick().isCreativeAction() + " - " + event.getClick().isRightClick() + " - " + event.getClick().isLeftClick() + " - " + event.getClick() +  " - " + event.getClick().isKeyboardClick());
+		if ((event.getClick() == ClickType.MIDDLE && event.getClick().isCreativeAction() == true) || event.getClick() == ClickType.UNKNOWN) {
 			if (event.getInventory().getType() != InventoryType.PLAYER) {
 				Player p = (Player) event.getWhoClicked();
 				if (p.getGameMode() == GameMode.CREATIVE) {
@@ -35,20 +41,25 @@ public class CreativeEvent implements Listener {
 							int amount = cursorItem.getAmount();
 							short data = cursorItem.getData().getData();
 							boolean checkEnchants = true;
-							
-							for (String s : cc.getConfigHandler().getStringList("EnabledFor")) {
-								try {
-									if (cursorItem.getType() == Material.valueOf(s)) {
-										event.setCursor(new ItemStack(Material.valueOf(s), amount, data));
-										checkEnchants = false;
-										break;
-									}
-								} catch (Exception e) {
-									CC.log.warning("Error on material: " + s + " Error: " + e.getMessage());
-								}
-							}
-							if (cursorItem.getEnchantments().isEmpty() == false && p.hasPermission("CNC.bypass.enchants") == false && checkEnchants == true) {
+
+							if (cursorItem.getItemMeta() instanceof SpawnEggMeta) {
 								event.setCursor(new ItemStack(cursorItem.getType(), amount, data));
+								checkEnchants = false;
+							} else {
+								for (String s : cc.getConfigHandler().getStringList("EnabledFor")) {
+									try {
+										if (cursorItem.getType() == Material.valueOf(s)) {
+											event.setCursor(new ItemStack(Material.valueOf(s), amount, data));
+											checkEnchants = false;
+											break;
+										}
+									} catch (Exception e) {
+										CC.log.warning("Error on material: " + s + " Error: " + e.getMessage());
+									}
+								}
+								if (cursorItem.getEnchantments().isEmpty() == false && p.hasPermission("CNC.bypass.enchants") == false && checkEnchants == true) {
+									event.setCursor(new ItemStack(cursorItem.getType(), amount, data));
+								}
 							}
 						}
 					}
@@ -56,11 +67,11 @@ public class CreativeEvent implements Listener {
 			}
 		}
 	}
-	
-	@EventHandler
+
+	@EventHandler(ignoreCancelled = true)
 	public void inventoryCreativeEvent(final InventoryCreativeEvent event) {
 		//Triggers on player inventory click
-		//CC.log.warning("Debug 2 - " + event.getClick().isCreativeAction() + " - " + event.getClick().isRightClick() + " - " + event.getClick().isLeftClick() + " - " + event.getClick());
+		//CC.log.warning("Debug 2 - " + event.getClick().isCreativeAction() + " - " + event.getClick().isRightClick() + " - " + event.getClick().isLeftClick() + " - " + event.getClick() + " - " + event.getSlotType() + " - " + event.getRawSlot() + " - " + event.getClickedInventory().getType().toString());
 		if (event.getClick() == ClickType.CREATIVE) {
 			Player p = (Player) event.getWhoClicked();
 			if (p.hasPermission("CNC.bypass") == false && event.getCursor() != null) {
@@ -69,22 +80,63 @@ public class CreativeEvent implements Listener {
 					int amount = cursorItem.getAmount();
 					short data = cursorItem.getData().getData();
 					boolean checkEnchants = true;
-					
-					for (String s : cc.getConfigHandler().getStringList("EnabledFor")) {
-						try {
-							if (cursorItem.getType() == Material.valueOf(s)) {
-								event.setCursor(new ItemStack(Material.valueOf(s), amount, data));
-								checkEnchants = false;
-								break;
+
+					if (cursorItem.getItemMeta() instanceof SpawnEggMeta) {
+						event.setCursor(new ItemStack(cursorItem.getType(), amount, data));
+						checkEnchants = false;
+					} else {
+						for (String s : cc.getConfigHandler().getStringList("EnabledFor")) {
+							try {
+								if (cursorItem.getType() == Material.valueOf(s)) {
+									event.setCursor(new ItemStack(Material.valueOf(s), amount, data));
+									checkEnchants = false;
+									break;
+								}
+							} catch (Exception e) {
+								CC.log.warning("Error on material: " + s + " Error: " + e.getMessage());
 							}
-						} catch (Exception e) {
-							CC.log.warning("Error on material: " + s + " Error: " + e.getMessage());
+						}
+						if (cursorItem.getEnchantments().isEmpty() == false && p.hasPermission("CNC.bypass.enchants") == false && checkEnchants == true) {
+							event.setCursor(new ItemStack(cursorItem.getType(), amount, data));
 						}
 					}
-					if (cursorItem.getEnchantments().isEmpty() == false && p.hasPermission("CNC.bypass.enchants") == false && checkEnchants == true) {
-						event.setCursor(new ItemStack(cursorItem.getType(), amount, data));
-					}
 				}
+			}
+		}
+	}
+
+	@EventHandler(ignoreCancelled = true)
+	public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+		final Player p = event.getPlayer();
+		Entity entity = event.getRightClicked();
+
+		ItemStack item = p.getInventory().getItemInMainHand();
+
+		if (item == null || item.getType() == Material.AIR)
+			return;
+
+		if (entity.getType().equals(EntityType.ITEM_FRAME)) {
+			if (p.hasPermission("CNC.bypass") == false && p.getGameMode() == GameMode.CREATIVE) {
+				event.setCancelled(true);
+				p.sendMessage(cc.getConfigHandler().getStringWithColor("ChatMessages.OpenSurvivalFrame"));
+			}
+		}
+	}
+
+	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	public void onPlayerArmorStandManipulate(PlayerArmorStandManipulateEvent event) {
+		final Player p = event.getPlayer();
+
+		ItemStack item = event.getPlayerItem();
+
+		if (item != null && (event.getArmorStandItem() == null || event.getArmorStandItem().getType() == Material.AIR)) {
+
+			if (item.getType() == Material.AIR)
+				return;
+
+			if (p.hasPermission("CNC.bypass") == false && p.getGameMode() == GameMode.CREATIVE) {
+				event.setCancelled(true);
+				p.sendMessage(cc.getConfigHandler().getStringWithColor("ChatMessages.OpenSurvivalArmor"));
 			}
 		}
 	}

--- a/Creative(+NBT)Control/src/plugin.yml
+++ b/Creative(+NBT)Control/src/plugin.yml
@@ -1,6 +1,6 @@
 name: CreativeNbtControl
 main: net.craftersland.creativeNBT.CC
-version: 1.13
+version: 1.15
 author: CraftersLand
 website: www.craftersland.net
 load: STARTUP


### PR DESCRIPTION
Hey I fixed the following dupping methods for creative players:
- Now players wont be able to abuse of UNKNOWN click type [See video of the method](https://imgur.com/a/apSfMyx)
- Now the plugin will check if the item is any type of spawn egg generator so its future proof [Video 1](https://imgur.com/a/YAW7JEN) and [Video 2](https://imgur.com/a/4YozC9J)
- Now players wont be able to dupe items with item frames [See video of the method](https://imgur.com/a/iE2Rr4h)
- Now players wont be able to dupe armor with armor-stands

Known issues:
- I currently dont really like the way this events work when player is using "CREATIVE" inventory type. The click type is always CREATIVE so we cant really known which click the player is actually performing. So because of this, sadly, any NBT item must be not touched if this inventory is opened or it will be lost. I did my best trying to fix this issue but couldnt find a way, the API sucks on this (according to md_5 it cant be fixed as its what the client says)