### PR TITLE
Some new dupping fixes!

### DIFF
--- a/Creative(+NBT)Control/src/config.yml
+++ b/Creative(+NBT)Control/src/config.yml
@@ -100,6 +100,9 @@ EnabledFor:
 #For 1.15 API
 - 'BEE_NEST'
 - 'BEEHIVE'
+- 'POTION'
+- 'SPLASH_POTION'
+- 'LINGERING_POTION'
 
 
 #Chat messages with color and format codes support.

--- a/Creative(+NBT)Control/src/config.yml
+++ b/Creative(+NBT)Control/src/config.yml
@@ -103,6 +103,7 @@ EnabledFor:
 - 'POTION'
 - 'SPLASH_POTION'
 - 'LINGERING_POTION'
+- 'TIPPED_ARROW'
 
 
 #Chat messages with color and format codes support.

--- a/Creative(+NBT)Control/src/net/craftersland/creativeNBT/events/CreativeEvent.java
+++ b/Creative(+NBT)Control/src/net/craftersland/creativeNBT/events/CreativeEvent.java
@@ -2,6 +2,8 @@ package net.craftersland.creativeNBT.events;
 
 import net.craftersland.creativeNBT.CC;
 
+import java.util.Map.Entry;
+
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
@@ -13,6 +15,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCreativeEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
@@ -25,6 +28,17 @@ public class CreativeEvent implements Listener {
 
 	public CreativeEvent(CC cc) {
 		this.cc = cc;
+	}
+	
+	@EventHandler(ignoreCancelled = true)
+	public void InventoryDragEvent(InventoryDragEvent event) {
+		int newAmount = 0;
+		for (Entry<Integer, ItemStack> is : event.getNewItems().entrySet())
+			newAmount += is.getValue().getAmount();
+			
+		//CC.log.warning("DragEvent - Type: " + event.getType().toString() + " - New Size: " + event.getNewItems().size() + " - New Amount: " + newAmount + " - Old Amount: " + event.getOldCursor().getAmount() + " - Result: " + event.getResult().toString());
+		if(newAmount > event.getOldCursor().getAmount())
+			event.setCancelled(true);
 	}
 
 	@EventHandler(ignoreCancelled = true)

--- a/Creative(+NBT)Control/src/net/craftersland/creativeNBT/events/CreativeEvent.java
+++ b/Creative(+NBT)Control/src/net/craftersland/creativeNBT/events/CreativeEvent.java
@@ -32,13 +32,15 @@ public class CreativeEvent implements Listener {
 	
 	@EventHandler(ignoreCancelled = true)
 	public void InventoryDragEvent(InventoryDragEvent event) {
-		int newAmount = 0;
-		for (Entry<Integer, ItemStack> is : event.getNewItems().entrySet())
-			newAmount += is.getValue().getAmount();
-			
-		//CC.log.warning("DragEvent - Type: " + event.getType().toString() + " - New Size: " + event.getNewItems().size() + " - New Amount: " + newAmount + " - Old Amount: " + event.getOldCursor().getAmount() + " - Result: " + event.getResult().toString());
-		if(newAmount > event.getOldCursor().getAmount())
-			event.setCancelled(true);
+		if (event.getWhoClicked().getGameMode() == GameMode.CREATIVE) {
+			int newAmount = 0;
+			for (Entry<Integer, ItemStack> is : event.getNewItems().entrySet())
+				newAmount += is.getValue().getAmount();
+
+			//CC.log.warning("DragEvent - Type: " + event.getType().toString() + " - New Size: " + event.getNewItems().size() + " - New Amount: " + newAmount + " - Old Amount: " + event.getOldCursor().getAmount() + " - Result: " + event.getResult().toString());
+			if (newAmount > event.getOldCursor().getAmount())
+				event.setCancelled(true);
+		}
 	}
 
 	@EventHandler(ignoreCancelled = true)

--- a/Creative(+NBT)Control/src/plugin.yml
+++ b/Creative(+NBT)Control/src/plugin.yml
@@ -1,6 +1,6 @@
 name: CreativeNbtControl
 main: net.craftersland.creativeNBT.CC
-version: 1.15
+version: 1.16
 author: CraftersLand
 website: www.craftersland.net
 load: STARTUP


### PR DESCRIPTION
Added potions to the config file so players cant bring from toolbars OP Potion/Splash_Potion/Lingering_Potion.

The downside of this is that they wont be able to get potions any longer from GMC. If you dont like this game mechanic change then reject this, but now that we have fixed bringing shulkers with toolbars we need to address OP potions (or any other illegal item)

Edit: also added tipped_arrows